### PR TITLE
Add missing prefixes: rdf and sd to SPARQL test cases. Fixes #24

### DIFF
--- a/test-cases/RMLTC0007b-SPARQL/mapping.ttl
+++ b/test-cases/RMLTC0007b-SPARQL/mapping.ttl
@@ -7,6 +7,7 @@
 @prefix sd:     <http://www.w3.org/ns/sparql-service-description#>.
 @prefix ex:     <http://example.com/> .
 @prefix hydra:  <http://www.w3.org/ns/hydra/core#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix foaf:   <http://xmlns.com/foaf/0.1/> .
 @base <http://example.com/base> .
 

--- a/test-cases/RMLTC0008c-SPARQL/mapping.ttl
+++ b/test-cases/RMLTC0008c-SPARQL/mapping.ttl
@@ -6,6 +6,7 @@
 @prefix ql:         <http://semweb.mmlab.be/ns/ql#> .
 @prefix activity:   <http://example.com/activity/> .
 @prefix d2rq:       <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix sd:         <http://www.w3.org/ns/sparql-service-description#> .
 @base <http://example.com/base/> .
 
 <#InputSPARQL>

--- a/test-cases/RMLTC0009a-SPARQL/mapping.ttl
+++ b/test-cases/RMLTC0009a-SPARQL/mapping.ttl
@@ -7,6 +7,7 @@
 @prefix activity:   <http://example.com/activity/> .
 @prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix d2rq:       <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix sd:         <http://www.w3.org/ns/sparql-service-description#> .
 @base <http://example.com/base/> .
 
 <#InputSPARQL1>

--- a/test-cases/RMLTC0009b-SPARQL/mapping.ttl
+++ b/test-cases/RMLTC0009b-SPARQL/mapping.ttl
@@ -7,6 +7,7 @@
 @prefix activity:   <http://example.com/activity/> .
 @prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix d2rq:       <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix sd:         <http://www.w3.org/ns/sparql-service-description#> .
 @base <http://example.com/base/> .
 
 <#InputSPARQL1>

--- a/test-cases/RMLTC0012b-SPARQL/mapping.ttl
+++ b/test-cases/RMLTC0012b-SPARQL/mapping.ttl
@@ -6,6 +6,7 @@
 @prefix ql:         <http://semweb.mmlab.be/ns/ql#> .
 @prefix activity:   <http://example.com/activity/> .
 @prefix d2rq:       <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix sd:         <http://www.w3.org/ns/sparql-service-description#> .
 @base <http://example.com/base/> .
 
 <#InputSPARQL1>


### PR DESCRIPTION
Some SPARQL test cases are missing `rdf` and `sd` prefixes.
This PR adds these prefixes to the related test cases.